### PR TITLE
Nonadiabatic matrix container class

### DIFF
--- a/devtools/ci/install_conda.sh
+++ b/devtools/ci/install_conda.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # based on OPS version
 
-sudo apt-get update
+#sudo apt-get update
 
 ### Install Miniconda
 

--- a/dynamiq_engine/__init__.py
+++ b/dynamiq_engine/__init__.py
@@ -3,3 +3,4 @@ import potentials
 import features
 
 from dynamiq_engine_core import DynamiqEngine, Snapshot, Topology
+from nonadiabatic_matrix import NonadiabaticMatrix

--- a/dynamiq_engine/nonadiabatic_matrix.py
+++ b/dynamiq_engine/nonadiabatic_matrix.py
@@ -6,11 +6,12 @@ class NonadiabaticMatrix(object):
         dct = {}
         for i in range(self.n_electronic_states):
             row = matrix[i]
-            assert(len(row) == self.n_electronic_states,
-                   "Input matrix not square")
+            assert (len(row)==self.n_electronic_states), \
+                    "Input matrix not square"
             for j in range(self.n_electronic_states):
-                elem = row[i]
-                dct[(i,j)] = elem
+                elem = row[j]
+                if elem != 0.0:
+                    dct[(i,j)] = elem
 
         self.matrix = matrix
         self.dictionary = dct
@@ -18,21 +19,21 @@ class NonadiabaticMatrix(object):
 
     @staticmethod
     def check_entries(list_of_entries):
-        pass # TODO
+        pass # TODO: this should verify types
 
     @classmethod
     def from_dictionary(cls, dct, n_electronic_states=None):
         from itertools import chain
-        res = cls.__new__()
+        res = cls.__new__(cls)
         cls.check_entries(dct.values())
         if n_electronic_states is None:
             n_electronic_states = max(list(chain.from_iterable(dct.keys())))+1
         res.n_electronic_states = n_electronic_states
         res.dictionary = dct
         matrix = []
-        for i in range(self.n_electronic_states):
-            row_i = [0.0]*self.n_electronic_states
-            for j in range(self.n_electronic_states):
+        for i in range(res.n_electronic_states):
+            row_i = [0.0]*res.n_electronic_states
+            for j in range(res.n_electronic_states):
                 try:
                     row_i[j] = dct[(i,j)]
                 except KeyError:

--- a/dynamiq_engine/nonadiabatic_matrix.py
+++ b/dynamiq_engine/nonadiabatic_matrix.py
@@ -62,7 +62,7 @@ class NonadiabaticMatrix(object):
         return res
 
 
-    def __get_item__(self, label):
+    def __getitem__(self, label):
         return self.dictionary[label]
 
 

--- a/dynamiq_engine/nonadiabatic_matrix.py
+++ b/dynamiq_engine/nonadiabatic_matrix.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+class NonadiabaticMatrix(object):
+    def __init__(self, matrix):
+        self.n_electronic_states = len(matrix)
+        dct = {}
+        for i in range(self.n_electronic_states):
+            row = matrix[i]
+            assert(len(row) == self.n_electronic_states,
+                   "Input matrix not square")
+            for j in range(self.n_electronic_states):
+                elem = row[i]
+                dct[(i,j)] = elem
+
+        self.matrix = matrix
+        self.dictionary = dct
+        self.check_entries(dct.values())
+
+    @staticmethod
+    def check_entries(list_of_entries):
+        pass # TODO
+
+    @classmethod
+    def from_dictionary(cls, dct, n_electronic_states=None):
+        from itertools import chain
+        res = cls.__new__()
+        cls.check_entries(dct.values())
+        if n_electronic_states is None:
+            n_electronic_states = max(list(chain.from_iterable(dct.keys())))+1
+        res.n_electronic_states = n_electronic_states
+        res.dictionary = dct
+        matrix = []
+        for i in range(self.n_electronic_states):
+            row_i = [0.0]*self.n_electronic_states
+            for j in range(self.n_electronic_states):
+                try:
+                    row_i[j] = dct[(i,j)]
+                except KeyError:
+                    pass
+            matrix.append(row_i)
+                
+        res.matrix = matrix
+        return res
+
+    def __get_item__(self, label):
+        return self.dictionary[label]
+
+    def numeric_matrix(self, snap):
+        pass
+        

--- a/dynamiq_engine/nonadiabatic_matrix.py
+++ b/dynamiq_engine/nonadiabatic_matrix.py
@@ -16,10 +16,27 @@ class NonadiabaticMatrix(object):
         self.matrix = matrix
         self.dictionary = dct
         self.check_entries(dct.values())
+        self.set_runnable_entries()
+
 
     @staticmethod
     def check_entries(list_of_entries):
         pass # TODO: this should verify types
+
+
+    def set_runnable_entries(self):
+        # TODO: better name for this function? sets the "mask" of the
+        # _numeric_matrix
+        n_elec = self.n_electronic_states
+        self._numeric_matrix = np.zeros((n_elec, n_elec))
+        self.runnable_entries = {}
+        for key in self.dictionary.keys():
+            val = self.dictionary[key]
+            if not np.isscalar(val):
+                self.runnable_entries[key] = val
+            else:
+                self._numeric_matrix[key] = val
+
 
     @classmethod
     def from_dictionary(cls, dct, n_electronic_states=None):
@@ -41,11 +58,17 @@ class NonadiabaticMatrix(object):
             matrix.append(row_i)
                 
         res.matrix = matrix
+        res.set_runnable_entries()
         return res
+
 
     def __get_item__(self, label):
         return self.dictionary[label]
 
+
     def numeric_matrix(self, snap):
-        pass
+        matrix = self._numeric_matrix.copy()
+        for key in self.runnable_entries.keys():
+            matrix[key] = self.runnable_entries[key](snap)
+        return matrix
         

--- a/dynamiq_engine/potentials/potential_energy_surface.py
+++ b/dynamiq_engine/potentials/potential_energy_surface.py
@@ -11,6 +11,12 @@ class PotentialEnergySurface(object):
     def H(self, snapshot):
         raise NotImplementedError("Using generic PES object")
 
+    def V(self, snapshot):
+        raise NotImplementedError("Using generic PES object")
+
+    def __call__(self, snapshot):
+        return self.V(snapshot)
+
     def kinetic_energy(self, snapshot):
         return 0.5*np.dot(snapshot.velocities, snapshot.momenta)
 
@@ -53,6 +59,9 @@ class OneDimensionalInteractionModel(PotentialEnergySurface):
     def H(self, snapshot):
         x = snapshot.coordinates[0]
         return self.kinetic_energy(snapshot) + self.interaction.f(x)
+
+    def V(self, snapshot):
+        return self.interaction.f(snapshot.coordinates[0])
 
     def set_dHdq(self, dHdq, snapshot):
         x = snapshot.coordinates[0]

--- a/dynamiq_engine/tests/test_nonadiabatic_matrix.py
+++ b/dynamiq_engine/tests/test_nonadiabatic_matrix.py
@@ -6,40 +6,47 @@ from dynamiq_engine.nonadiabatic_matrix import *
 
 class testNonadiabaticMatrix(object):
     def setup(self):
+        import dynamiq_engine.potentials as pes
+        self.V1 = pes.OneDimensionalInteractionModel(
+            pes.interactions.HarmonicOscillatorInteraction(k=2.0, x0=0.0)
+        )
+        self.V2 = pes.OneDimensionalInteractionModel(
+            pes.interactions.HarmonicOscillatorInteraction(k=3.0, x0=1.0)
+        )
         self.numbers_matrix = [[1.5, 2.0], [2.0, 0.0]]
-        self.numbers_3x3 = [[1.5, 2.0, 0.0], [2.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
-        self.functions_H = []
-        self.mixed_H = []
         self.numbers_dict = {(0,0) : 1.5, (0,1) : 2.0, (1,0) : 2.0}
-        self.functions_dict = [0.0]
-        pass
+        self.mixed_matrix = [[self.V1, 2.0], [2.0, self.V2]]
+        self.mixed_dict = {(0,0) : self.V1, (0,1) : 2.0, 
+                           (1,0) : 2.0, (1,1) : self.V2}
 
-    def check_build_from_number_matrix(self):
+    def test_build_from_number_matrix(self):
         na = NonadiabaticMatrix(self.numbers_matrix)
         assert_equal(na.dictionary, self.numbers_dict)
 
-    def check_build_from_mixed_matrix(self):
-        raise SkipTest
-
-    def check_build_from_number_dictionary(self):
+    def test_build_from_number_dictionary(self):
         na = NonadiabaticMatrix.from_dictionary(self.numbers_dict)
         assert_equal(na.matrix, self.numbers_matrix)
-        #assert_equal(na.numeric_matrix(self.snap), self.numbers_matrix)
         na3 = NonadiabaticMatrix.from_dictionary(self.numbers_dict, 3)
         assert_equal(na3.n_electronic_states, 3)
-        assert_equal(na3.matrix, self.numbers_3x3)
+        numbers_3x3 = [[1.5, 2.0, 0.0], [2.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        assert_equal(na3.matrix, numbers_3x3)
+
+    def test_build_from_mixed_matrix(self):
+        na = NonadiabaticMatrix(self.mixed_matrix)
+        assert_equal(na.dictionary, self.mixed_dict)
+
+    def test_build_from_mixed_dictionary(self):
+        na = NonadiabaticMatrix.from_dictionary(self.mixed_dict)
+        assert_equal(na.matrix, self.mixed_matrix)
+
+    def test_numeric_matrix_number_input(self):
+        #assert_equal(na.numeric_matrix(self.snap), self.numbers_matrix)
         raise SkipTest
 
-    def check_build_from_mixed_dictionary(self):
+    def test_numeric_matrix_mixed_input(self):
         raise SkipTest
 
-    def check_numeric_matrix_numeric_input(self):
-        raise SkipTest
-
-    def check_numeric_matrix_function_input(self):
-        raise SkipTest
-
-    def check_get_item(self):
+    def test_get_item(self):
         raise SkipTest
 
     def bad_entries_string(self):

--- a/dynamiq_engine/tests/test_nonadiabatic_matrix.py
+++ b/dynamiq_engine/tests/test_nonadiabatic_matrix.py
@@ -18,6 +18,14 @@ class testNonadiabaticMatrix(object):
         self.mixed_matrix = [[self.V1, 2.0], [2.0, self.V2]]
         self.mixed_dict = {(0,0) : self.V1, (0,1) : 2.0, 
                            (1,0) : 2.0, (1,1) : self.V2}
+        self.snap = dynq.Snapshot(
+            coordinates=np.array([0.5]),
+            momenta=np.array([0.0]),
+            # arbitrarily chose V1: has the same (n_atoms, n_spatial) as any
+            # other. A bit weird; ideally this will change when JHP changes
+            # Snapshots a little.
+            topology=dynq.Topology(masses=np.array([1.0]), potential=self.V1)
+        )
 
     def test_build_from_number_matrix(self):
         na = NonadiabaticMatrix(self.numbers_matrix)
@@ -40,8 +48,9 @@ class testNonadiabaticMatrix(object):
         assert_equal(na.matrix, self.mixed_matrix)
 
     def test_numeric_matrix_number_input(self):
-        #assert_equal(na.numeric_matrix(self.snap), self.numbers_matrix)
-        raise SkipTest
+        na = NonadiabaticMatrix(self.numbers_matrix)
+        assert_array_almost_equal(na.numeric_matrix(self.snap),
+                                  np.array(self.numbers_matrix))
 
     def test_numeric_matrix_mixed_input(self):
         raise SkipTest

--- a/dynamiq_engine/tests/test_nonadiabatic_matrix.py
+++ b/dynamiq_engine/tests/test_nonadiabatic_matrix.py
@@ -1,0 +1,33 @@
+import dynamiq_engine as dynq
+import numpy as np
+from tools import *
+import stubs
+from dynamiq_engine.nonadiabatic_matrix import *
+
+class testNonadiabaticMatrix(object):
+    def setup(self):
+        pass
+
+    def check_build_from_number_matrix(self):
+        raise SkipTest
+
+    def check_build_from_mixed_matrix(self):
+        raise SkipTest
+
+    def check_build_from_number_dictionary(self):
+        raise SkipTest
+
+    def check_build_from_mixed_dictionary(self):
+        raise SkipTest
+
+    def check_numeric_matrix_numeric_input(self):
+        raise SkipTest
+
+    def check_numeric_matrix_fucntion_input(self):
+        raise SkipTest
+
+    def check_get_item(self):
+        raise SkipTest
+
+    def bad_entries_string(self):
+        raise SkipTest

--- a/dynamiq_engine/tests/test_nonadiabatic_matrix.py
+++ b/dynamiq_engine/tests/test_nonadiabatic_matrix.py
@@ -6,15 +6,28 @@ from dynamiq_engine.nonadiabatic_matrix import *
 
 class testNonadiabaticMatrix(object):
     def setup(self):
+        self.numbers_matrix = [[1.5, 2.0], [2.0, 0.0]]
+        self.numbers_3x3 = [[1.5, 2.0, 0.0], [2.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
+        self.functions_H = []
+        self.mixed_H = []
+        self.numbers_dict = {(0,0) : 1.5, (0,1) : 2.0, (1,0) : 2.0}
+        self.functions_dict = [0.0]
         pass
 
     def check_build_from_number_matrix(self):
-        raise SkipTest
+        na = NonadiabaticMatrix(self.numbers_matrix)
+        assert_equal(na.dictionary, self.numbers_dict)
 
     def check_build_from_mixed_matrix(self):
         raise SkipTest
 
     def check_build_from_number_dictionary(self):
+        na = NonadiabaticMatrix.from_dictionary(self.numbers_dict)
+        assert_equal(na.matrix, self.numbers_matrix)
+        #assert_equal(na.numeric_matrix(self.snap), self.numbers_matrix)
+        na3 = NonadiabaticMatrix.from_dictionary(self.numbers_dict, 3)
+        assert_equal(na3.n_electronic_states, 3)
+        assert_equal(na3.matrix, self.numbers_3x3)
         raise SkipTest
 
     def check_build_from_mixed_dictionary(self):
@@ -23,7 +36,7 @@ class testNonadiabaticMatrix(object):
     def check_numeric_matrix_numeric_input(self):
         raise SkipTest
 
-    def check_numeric_matrix_fucntion_input(self):
+    def check_numeric_matrix_function_input(self):
         raise SkipTest
 
     def check_get_item(self):

--- a/dynamiq_engine/tests/test_nonadiabatic_matrix.py
+++ b/dynamiq_engine/tests/test_nonadiabatic_matrix.py
@@ -26,6 +26,8 @@ class testNonadiabaticMatrix(object):
             # Snapshots a little.
             topology=dynq.Topology(masses=np.array([1.0]), potential=self.V1)
         )
+        # V1(snap) = 0.5*2.0*(0.5-0.0)**2 = 0.25
+        # V2(snap) = 0.5*3.0*(0.5-1.0)**2 = 0.375
 
     def test_build_from_number_matrix(self):
         na = NonadiabaticMatrix(self.numbers_matrix)
@@ -53,10 +55,15 @@ class testNonadiabaticMatrix(object):
                                   np.array(self.numbers_matrix))
 
     def test_numeric_matrix_mixed_input(self):
-        raise SkipTest
+        na = NonadiabaticMatrix(self.mixed_matrix)
+        expected = np.array([[0.25, 2.0], [2.0, 0.375]])
+        assert_array_almost_equal(na.numeric_matrix(self.snap), expected)
 
-    def test_get_item(self):
-        raise SkipTest
+    def test_getitem(self):
+        mixed_matrix = NonadiabaticMatrix(self.mixed_matrix)
+        mixed_dict = NonadiabaticMatrix.from_dictionary(self.mixed_dict)
+        assert_equal(mixed_matrix[1,1], self.V2)
+        assert_equal(mixed_dict[1,1], self.V2)
 
     def bad_entries_string(self):
         raise SkipTest


### PR DESCRIPTION
The `NonadiabaticMatrix` class will be a general wrapper for nonadiabatic dynamics. A few important points -- it should:

- [x] Create from dictionary and obtain matrix
- [x] Create from matrix and obtain dictionary
- [x] Allow constant numbers or nuclear PES as the matrix elements
- [x] Return the numeric value if called with a snapshot of the nuclear system

All of this allows it to be used for multiple treatments of nonadiabatic dynamics (including MMST, SOFT [for small systems], or surface hopping), as well as (with modification) for other engines (e.g., openmm-mmst).