### PR TITLE
More pairwise interactions

### DIFF
--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -79,13 +79,22 @@ class MorseInteraction(PairwiseInteraction):
         self.x0 = x0
 
     def f(self, x):
-        pass
+        exp_mbetadx = np.exp(-self.beta * (x - self.x0))
+        return self.D * (1.0 - exp_mbetadx) * (1.0 - exp_mbetadx)
 
     def dfdx(self, x):
-        pass
+        exp_mbetadx = np.exp(-self.beta * (x - self.x0))
+        two_Db = 2*self.D*self.beta
+        return two_Db * (exp_mbetadx - exp_mbetadx * exp_mbetadx)
 
     def d2fdx2(self, x):
-        pass
+        exp_mbetadx = np.exp(-self.beta * (x - self.x0))
+        two_Db = 2*self.D*self.beta
+        return two_Db*self.beta * (2*exp_mbetadx*exp_mbetadx - exp_mbetadx)
+
+
+class QuarticInteraction(PairwiseInteraction):
+    pass
 
 class GaussianInteraction(PairwiseInteraction):
     pass
@@ -94,9 +103,6 @@ class LennardJonesInteraction(PairwiseInteraction):
     pass
 
 class WCAInteraction(PairwiseInteraction):
-    pass
-
-class QuarticInteraction(PairwiseInteraction):
     pass
 
 class GeneralizedWCAInteraction(PairwiseInteraction):

--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -48,10 +48,42 @@ class HarmonicOscillatorInteraction(PairwiseInteraction):
 
 
 class TanhInteraction(PairwiseInteraction):
-    pass
+    def __init__(self, a, V0, R0=0.0):
+        self.a = a
+        self.V0 = V0
+        self.R0 = R0
+        # TODO: might be good to have a way to set position-dependent var
+        # (tanh_aR and sech_aR) as a first step of the integrator, avoiding
+        # repeated computation. Requires careful usage within the integrator
+
+    def f(self, x):
+        tanh_aR = np.tanh(self.a * (x-self.R0))
+        return self.V0 * tanh_aR
+
+    def dfdx(self, x):
+        sech_aR = 1.0 / np.cosh(self.a * (x - self.R0))
+        return self.V0*self.a*sech_aR*sech_aR
+
+    def d2fdx2(self, x):
+        sech_aR = 1.0 / np.cosh(self.a * (x - self.R0))
+        tanh_aR = np.tanh(self.a * (x-self.R0))
+        return -2.0 * self.V0 * self.a * self.a * sech_aR * sech_aR * tanh_aR
+
 
 class MorseInteraction(PairwiseInteraction):
-    pass
+    def __init__(self, D, beta, x0):
+        self.D = D
+        self.beta = beta
+        self.x0 = x0
+
+    def f(self, x):
+        pass
+
+    def dfdx(self, x):
+        pass
+
+    def d2fdx2(self, x):
+        pass
 
 class GaussianInteraction(PairwiseInteraction):
     pass

--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -94,7 +94,29 @@ class MorseInteraction(PairwiseInteraction):
 
 
 class QuarticInteraction(PairwiseInteraction):
-    pass
+    def __init__(self, A, B, C, E0, x0):
+        x0_2 = x0*x0
+        x0_3 = x0_2 * x0
+        x0_4 = x0_3 * x0
+        self.alpha = A
+        self.beta = -4*A*x0 + B
+        self.gamma = 6*A*x0_2 - 3*B*x0 + C
+        self.delta = -4*A*x0_3 +3*B*x0_2 - 2*C*x0 + D
+        self.epsilon = A*x0_4 - B*x0_3 + C*x0_2 - D*x0 + E0
+
+    def f(self, x):
+        x2 = x*x
+        return (self.alpha*x2*x2 + self.beta*x2*x + self.gamma*x2 +
+                self.delta*x + self.epsilon)
+
+    def dfdx(self, x):
+        x2 = x*x
+        return (4.0*self.alpha*x2*x + 3.0*self.beta*x2 + 2.0*self.gamma*x +
+                self.delta)
+
+    def d2fdx2(self, x):
+        x2 = x*x
+        return (12.0*self.alpha*x2 = 6.0*self.beta*x + 2.0*self.gamma)
 
 class GaussianInteraction(PairwiseInteraction):
     pass

--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -116,7 +116,7 @@ class QuarticInteraction(PairwiseInteraction):
 
     def d2fdx2(self, x):
         x2 = x*x
-        return (12.0*self.alpha*x2 = 6.0*self.beta*x + 2.0*self.gamma)
+        return (12.0*self.alpha*x2 + 6.0*self.beta*x + 2.0*self.gamma)
 
 class GaussianInteraction(PairwiseInteraction):
     pass

--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -47,4 +47,25 @@ class HarmonicOscillatorInteraction(PairwiseInteraction):
         return self.k
 
 
+class TanhInteraction(PairwiseInteraction):
+    pass
+
+class MorseInteraction(PairwiseInteraction):
+    pass
+
+class GaussianInteraction(PairwiseInteraction):
+    pass
+
+class LennardJonesInteraction(PairwiseInteraction):
+    pass
+
+class WCAInteraction(PairwiseInteraction):
+    pass
+
+class QuarticInteraction(PairwiseInteraction):
+    pass
+
+class GeneralizedWCAInteraction(PairwiseInteraction):
+    # arbitrary powers
+    pass
 

--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 
 class PairwiseInteraction(object):
     def f(self, x):

--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -94,7 +94,7 @@ class MorseInteraction(PairwiseInteraction):
 
 
 class QuarticInteraction(PairwiseInteraction):
-    def __init__(self, A, B, C, E0, x0):
+    def __init__(self, A, B, C, D, E0, x0):
         x0_2 = x0*x0
         x0_3 = x0_2 * x0
         x0_4 = x0_3 * x0

--- a/dynamiq_engine/tests/test_pairwise_interactions.py
+++ b/dynamiq_engine/tests/test_pairwise_interactions.py
@@ -120,4 +120,34 @@ class testMorseInteraction(object):
         }
         check_function(self.morse.d2fdx2, tests)
 
+class testQuarticInteraction(object):
+    def setup(self):
+        self.quartic = QuarticInteraction(1.5, 1.25, 2.0, 1.0, 0.25, 0.5)
 
+    def test_f(self):
+        tests = {
+            -1.0 : 6.625,
+            0.0 : 0.1875,
+            0.5 : 0.25,
+            2.0 : 18.0625
+        }
+        check_function(self.quartic.f, tests)
+        check_function(self.quartic, tests)
+
+    def test_dfdx(self):
+        tests = {
+            -1.0 : -16.8125,
+            0.0 : -0.8125,
+            0.5 : 1.0,
+            2.0 : 35.6875
+        }
+        check_function(self.quartic.dfdx, tests)
+
+    def test_d2fdx2(self):
+        tests = {
+            -1.0 : 33.25,
+            0.0 : 4.75,
+            0.5 : 4.0,
+            2.0 : 55.75
+        }
+        check_function(self.quartic.d2fdx2, tests)

--- a/dynamiq_engine/tests/test_pairwise_interactions.py
+++ b/dynamiq_engine/tests/test_pairwise_interactions.py
@@ -88,3 +88,36 @@ class testTanhInteraction(object):
         }
         check_function(self.tanh.d2fdx2, tests)
 
+class testMorseInteraction(object):
+    def setup(self):
+        self.morse = MorseInteraction(D=30.0, beta=0.08, x0=0.5)
+
+    def test_f(self):
+        tests = {
+            -1.0 : 0.487663414879601,
+            0.0 : 0.0499655787054630,
+            0.5 : 0.0,
+            5.0 : 2.74198811453729
+        }
+        check_function(self.morse.f, tests)
+        check_function(self.morse, tests)
+
+    def test_dfdx(self):
+        tests = {
+            -1.0 : -0.690011033961740,
+            0.0 : -0.203886208716337,
+            0.5 : 0.0,
+            5.0 : 1.01243553653309
+        }
+        check_function(self.morse.dfdx, tests)
+
+    def testd2fdx2(self):
+        tests = {
+            -1.0 : 0.543360556440359,
+            0.0 : 0.432293130684491,
+            0.5 : 0.384000000000000,
+            5.0 : 0.105918023365982
+        }
+        check_function(self.morse.d2fdx2, tests)
+
+

--- a/dynamiq_engine/tests/test_pairwise_interactions.py
+++ b/dynamiq_engine/tests/test_pairwise_interactions.py
@@ -56,4 +56,35 @@ class testHarmonicOscillatorInteraction(object):
         }
         check_function(self.ho.d2fdx2, tests)
 
-    
+class testTanhInteraction(object):
+    def setup(self):
+        self.tanh = TanhInteraction(a=0.75, V0=0.1, R0=0.5)
+
+    def test_f(self):
+        tests = {
+            0.0 : -0.0358357398350786,
+            0.5 : 0.0,
+            1.0 : 0.0358357398350786,
+            2.0 : 0.0809301070201781
+        }
+        check_function(self.tanh.f, tests)
+        check_function(self.tanh, tests)
+
+    def test_dfdx(self):
+        tests = {
+            0.0 : 0.0653684981285442,
+            0.5 : 0.0750000000000000,
+            1.0 : 0.0653684981285442,
+            2.0 : 0.0258773833327689
+        }
+        check_function(self.tanh.dfdx, tests)
+
+    def test_d2fdx2(self):
+        tests = {
+            0.0 : 0.0351379273851650,
+            0.5 : 0.0,
+            1.0 : -0.0351379273851650,
+            2.0 : -0.0314138910378474
+        }
+        check_function(self.tanh.d2fdx2, tests)
+


### PR DESCRIPTION
Adding several more pairwise interactions to be used when building up common models:

- [x] tanh
- [x] Morse
- [x] quartic

A future PR will include several more, including Gaussian, Lennard-Jones, WCA, and Generalized WCA (i.e., WCA with arbitrary powers). These first 3 are being merged first to be used for various testing purposes.