### PR TITLE
MMST (without monodromy so far)

### DIFF
--- a/dynamiq_engine/__init__.py
+++ b/dynamiq_engine/__init__.py
@@ -2,5 +2,7 @@ import integrators
 import potentials
 import features
 
-from dynamiq_engine_core import DynamiqEngine, Snapshot, Topology
+from dynamiq_engine_core import (
+    DynamiqEngine, Topology, Snapshot, MMSTSnapshot
+)
 from nonadiabatic_matrix import NonadiabaticMatrix

--- a/dynamiq_engine/dynamiq_engine_core.py
+++ b/dynamiq_engine/dynamiq_engine_core.py
@@ -63,6 +63,25 @@ class Snapshot(paths.AbstractSnapshot):
         self.topology = other.topology
         self.is_reversed = other.is_reversed
 
+@lazy_loading_attributes('_reversed')
+class MMSTSnapshot(Snapshot):
+    __features__ = [
+        paths.features.coordinates,
+        features.momenta,
+        features.electronic_coordinates,
+        features.electronic_momenta
+    ]
+    def __init__(self, coordinates=None, momenta=None, monodromy=None,
+                 electronic_coordinates=None, electronic_momenta=None,
+                 is_reversed=False, topology=None, reversed_copy=None):
+        super(MMSTSnapshot, self).__init__(
+            coordinates=coordinates, momenta=momenta, monodromy=monodromy,
+            is_reversed=is_reversed, topology=topology,
+            reversed_copy=reversed_copy
+        )
+        self.electronic_coordinates = electronic_coordinates
+        self.electronic_momenta = electronic_momenta
+
 
 class Topology(paths.Topology):
     def __init__(self, masses, potential):

--- a/dynamiq_engine/features/__init__.py
+++ b/dynamiq_engine/features/__init__.py
@@ -1,1 +1,3 @@
 import momenta
+import electronic_momenta
+import electronic_coordinates

--- a/dynamiq_engine/features/electronic_coordinates.py
+++ b/dynamiq_engine/features/electronic_coordinates.py
@@ -1,0 +1,8 @@
+_variables = ['electronic_coordinates']
+
+def _init(store):
+    store.create_variable(
+        'electronic_coordinates', 'numpy.float32', dimensions('n_electronic',),
+        description="the coordinate for a given electronic degree of freedom",
+        chunksizes=(1, 'n_electronic')
+    )

--- a/dynamiq_engine/features/electronic_momenta.py
+++ b/dynamiq_engine/features/electronic_momenta.py
@@ -1,0 +1,8 @@
+_variables = ['electronic_momenta']
+
+def _init(store):
+    store.create_variable(
+        'electronic_momenta', 'numpy.float32', dimensions('n_electronic',),
+        description="the momentum for a given electronic degree of freedom",
+        chunksizes=(1, 'n_electronic')
+    )

--- a/dynamiq_engine/integrators/candy_rozmus_4.py
+++ b/dynamiq_engine/integrators/candy_rozmus_4.py
@@ -51,10 +51,10 @@ class CandyRozmus4(Integrator):
         # wrap PBCs if necessary
 
 class CandyRozmus4MMST(CandyRozmus4):
-    def __init__(dt, potential, n_frames=1):
+    def __init__(self, dt, potential, n_frames=1):
         super(CandyRozmus4MMST, self).__init__(dt, potential, n_frames)
-        self.local_electronic_dHdp = np.zeros(potential.n_electronic)
-        self.local_electronic_dHdq = np.zeros(potential.n_electronic)
+        self.local_electronic_dHdp = np.zeros(potential.n_electronic_states)
+        self.local_electronic_dHdq = np.zeros(potential.n_electronic_states)
     
     def position_update(self, potential, snap, k):
         potential.set_dHdp(self.local_dHdp, snap)

--- a/dynamiq_engine/nonadiabatic_matrix.py
+++ b/dynamiq_engine/nonadiabatic_matrix.py
@@ -23,6 +23,8 @@ class NonadiabaticMatrix(object):
     def check_entries(list_of_entries):
         pass # TODO: this should verify types
 
+    def keys(self):
+        return self.dictionary.keys()
 
     def set_runnable_entries(self):
         # TODO: better name for this function? sets the "mask" of the

--- a/dynamiq_engine/nonadiabatic_matrix.py
+++ b/dynamiq_engine/nonadiabatic_matrix.py
@@ -24,7 +24,8 @@ class NonadiabaticMatrix(object):
         pass # TODO: this should verify types
 
     def keys(self):
-        return self.dictionary.keys()
+        """Keys, assuming we have an upper triangular matrix"""
+        return [(i,j) for (i,j) in self.dictionary.keys() if i<=j]
 
     def set_runnable_entries(self):
         # TODO: better name for this function? sets the "mask" of the

--- a/dynamiq_engine/potentials/__init__.py
+++ b/dynamiq_engine/potentials/__init__.py
@@ -1,6 +1,7 @@
 import pairwise_interactions as interactions
 
 from potential_energy_surface import (
-    PotentialEnergySurface, OneDimensionalInteractionModel
+    PotentialEnergySurface, OneDimensionalInteractionModel,
 )
 
+from mmst_hamiltonian import MMSTHamiltonian

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -47,14 +47,15 @@ class MMSTHamiltonian(PotentialEnergySurface):
         energy. V_{eff} is everything else.
         """
         elect = self._elect_cache(snapshot)
-        V_ij = self.H_matrix.numeric(snapshot)
+        V_ij = self.H_matrix.numeric_matrix(snapshot)
        
+        print self.H_matrix.keys()
         V = sum([elect[key] * V_ij[key] for key in self.H_matrix.keys()])
         return V
 
     
     def set_electronic_dHdq(self, electronic_dHdq, snapshot):
-        V_ij = self.H_matrix.numeric(snapshot)
+        V_ij = self.H_matrix.numeric_matrix(snapshot)
 
         for i in range(self.n_electronic_states):
             electronic_dHdq[i] = sum(
@@ -74,7 +75,7 @@ class MMSTHamiltonian(PotentialEnergySurface):
 
 
     def set_electronic_dHdp(self, electronic_dHdp, snapshot):
-        V_ij = self.H_matrix.numeric(snapshot)
+        V_ij = self.H_matrix.numeric_matrix(snapshot)
 
         for i in range(self.n_electronic_states):
             electronic_dHdp[i] = sum(

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -17,9 +17,6 @@ class MMSTHamiltonian(PotentialEnergySurface):
         self.electronic_first = electronic_first
         pass
 
-    def nuclear_snapshot(self, snap):
-        pass
-
     def H(self, snap):
         pass
 

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -1,15 +1,23 @@
+import dynamiq_engine as dynq
+from dynamiq_engine.potentials import PotentialEnergySurface
+import numpy as np
 
 class MMSTHamiltonian(PotentialEnergySurface):
-    """Meyer-Miller-Stock-Thoss mapped electron Hamiltonian
+    """Meyer-Miller-Stock-Thoss mapped electron Hamiltonian.
 
     Parameters
     ----------
-    H_matrix : matrix-like
-        The input Hamiltonian matrix. By "matrix-like", it is meant that it
-        must have the following properties
+    H_matrix : dynamiq_engine.NonadiabaticMatrix
+        The input Hamiltonian matrix. 
     """
 
-    def __init__(self, H_matrix):
+    def __init__(self, H_matrix, electronic_first=True):
+        self.H_matrix = H_matrix
+        self.n_electronic_states = H_matrix.n_electronic_states
+        self.electronic_first = electronic_first
+        pass
+
+    def nuclear_snapshot(self, snap):
         pass
 
     def H(self, snap):

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -23,10 +23,16 @@ class MMSTHamiltonian(PotentialEnergySurface):
     def V(self, snap):
         pass
     
-    def dHdq(self, snap):
+    def set_electronic_dHdq(self, electronic_dHdq, snapshot):
         pass
 
-    def dHdp(self, snap):
+    def set_dHdq(self, dHdq, snapshot):
+        pass
+
+    def set_electronic_dHdp(self, electronic_dHdq, snapshot):
+        pass
+
+    def set_dHdp(self, dHdq, snapshot):
         pass
 
     # following are to be done later

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -17,8 +17,16 @@ class MMSTHamiltonian(PotentialEnergySurface):
         self.electronic_first = electronic_first
 
         runnables = self.H_matrix.runnable_entries.values()
-        self.n_spatial = runnables[0].n_spatial
-        self.n_atoms = runnables[0].n_atoms
+        try:
+            runnable_0 = runnables[0]
+        except IndexError:
+            # can this work?
+            self.n_spatial = 0
+            self.n_atoms = 0
+        else:
+            self.n_spatial = runnables[0].n_spatial
+            self.n_atoms = runnables[0].n_atoms
+
         err_str = " not the same in all nonadiabatic matrix entries."
         for runnable in runnables:
             assert runnable.n_spatial == self.n_spatial, "n_spatial" + err_str

--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -119,7 +119,7 @@ class QuarticInteraction(PairwiseInteraction):
         return (12.0*self.alpha*x2 + 6.0*self.beta*x + 2.0*self.gamma)
 
 class GaussianInteraction(PairwiseInteraction):
-    def __init__(self, A, alpha, x0):
+    def __init__(self, A, alpha, x0=0.0):
         self.A = A
         self.alpha = alpha
         self.x0 = x0
@@ -137,7 +137,7 @@ class GaussianInteraction(PairwiseInteraction):
     def d2fdx2(self, x):
         dx = x-self.x0
         func = self.A*np.exp(-self.alpha*dx*dx)
-        return 2.0*self.alpha*(2.0*dx*dx - 1.0)*func
+        return 2.0*self.alpha*(2.0*self.alpha*dx*dx - 1.0)*func
 
 class LennardJonesInteraction(PairwiseInteraction):
     pass

--- a/dynamiq_engine/potentials/pairwise_interactions.py
+++ b/dynamiq_engine/potentials/pairwise_interactions.py
@@ -119,7 +119,25 @@ class QuarticInteraction(PairwiseInteraction):
         return (12.0*self.alpha*x2 + 6.0*self.beta*x + 2.0*self.gamma)
 
 class GaussianInteraction(PairwiseInteraction):
-    pass
+    def __init__(self, A, alpha, x0):
+        self.A = A
+        self.alpha = alpha
+        self.x0 = x0
+
+    def f(self, x):
+        dx = x-self.x0
+        func = self.A*np.exp(-self.alpha*dx*dx)
+        return func
+
+    def dfdx(self, x):
+        dx = x-self.x0
+        func = self.A*np.exp(-self.alpha*dx*dx)
+        return -2.0*self.alpha*dx*func
+
+    def d2fdx2(self, x):
+        dx = x-self.x0
+        func = self.A*np.exp(-self.alpha*dx*dx)
+        return 2.0*self.alpha*(2.0*dx*dx - 1.0)*func
 
 class LennardJonesInteraction(PairwiseInteraction):
     pass

--- a/dynamiq_engine/potentials/potential_energy_surface.py
+++ b/dynamiq_engine/potentials/potential_energy_surface.py
@@ -9,7 +9,7 @@ class PotentialEnergySurface(object):
         Level required to simulate the system
     """
     def H(self, snapshot):
-        raise NotImplementedError("Using generic PES object")
+        return self.V(snapshot) + self.kinetic_energy(snapshot)
 
     def V(self, snapshot):
         raise NotImplementedError("Using generic PES object")
@@ -34,6 +34,7 @@ class PotentialEnergySurface(object):
         return dHdp
 
     def set_dHdp(self, dHdp, snapshot):
+        np.copyto(snapshot.velocities, dHdp)
         raise NotImplementedError("Using generic PES object")
 
     def d2Hdq2(self, snapshot):

--- a/dynamiq_engine/potentials/potential_energy_surface.py
+++ b/dynamiq_engine/potentials/potential_energy_surface.py
@@ -56,10 +56,6 @@ class OneDimensionalInteractionModel(PotentialEnergySurface):
         self.dynamics_level = 0
         self.interaction = interaction
 
-    def H(self, snapshot):
-        x = snapshot.coordinates[0]
-        return self.kinetic_energy(snapshot) + self.interaction.f(x)
-
     def V(self, snapshot):
         return self.interaction.f(snapshot.coordinates[0])
 

--- a/dynamiq_engine/potentials/potential_energy_surface.py
+++ b/dynamiq_engine/potentials/potential_energy_surface.py
@@ -34,8 +34,7 @@ class PotentialEnergySurface(object):
         return dHdp
 
     def set_dHdp(self, dHdp, snapshot):
-        np.copyto(snapshot.velocities, dHdp)
-        raise NotImplementedError("Using generic PES object")
+        np.copyto(dHdp, snapshot.velocities)
 
     def d2Hdq2(self, snapshot):
         raise NotImplementedError("Using generic PES object")

--- a/dynamiq_engine/tests/stubs.py
+++ b/dynamiq_engine/tests/stubs.py
@@ -2,15 +2,15 @@ import dynamiq_engine as dynq
 import numpy as np
 
 class PotentialStub(dynq.potentials.PotentialEnergySurface):
-    def __init__(self):
-        self.n_atoms = 1
-        self.n_spatial = 1
+    def __init__(self, n_atoms=1, n_spatial=1):
+        self.n_atoms = n_atoms
+        self.n_spatial = n_spatial
 
     def H(self, snapshot):
         return 0.0
 
     def dHdq(self, snapshot):
-        return np.array([0.0])
+        return np.array([[0.0]*self.n_spatial]*self.n_atoms)
 
     def dHdp(self, snapshot):
-        return np.array([0.0])
+        return np.array([[0.0]*self.n_spatial]*self.n_atoms)

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -64,7 +64,58 @@ class testCandyRozmus4(object):
         assert_array_almost_equal(new_snap.momenta, exact_0x10['p'])
 
 class testCandyRozmus4MMST(object):
-    def setup(self):
+    def test_step_uncoupled(self):
+        from math import sqrt
+        # test uncoupled
+        uncoupled_matrix = dynq.NonadiabaticMatrix([[2.0, 0.0], [0.0, 3.0]])
+        uncoupled = dynq.potentials.MMSTHamiltonian(uncoupled_matrix)
+        uncoupled_topology = dynq.Topology(masses=[], potential=uncoupled)
+        uncoupled_snap = dynq.MMSTSnapshot(
+            coordinates=np.array([]), momenta=np.array([]),
+            electronic_coordinates=np.array([1.0, 1.0]),
+            electronic_momenta=np.array([1.0, 1.0]),
+            topology=uncoupled_topology
+        )
+        uncoupled_integ = CandyRozmus4MMST(0.01, uncoupled)
+        for i in range(10):
+            uncoupled_integ.step(uncoupled, uncoupled_snap, uncoupled_snap)
+
+        exact_1 = exact_ho(time=0.1, omega=2.0, m=1.0/2.0, q0=1.0, p0=1.0)
+        exact_2 = exact_ho(time=0.1, omega=3.0, m=1.0/3.0, q0=1.0, p0=1.0)
+        predicted_coordinates = [exact_1['q'][0], exact_2['q'][0]]
+        predicted_momenta = [exact_1['p'][0], exact_2['p'][0]]
+        assert_array_almost_equal(uncoupled_snap.electronic_coordinates,
+                                  np.array(predicted_coordinates))
+        assert_array_almost_equal(uncoupled_snap.electronic_momenta,
+                                  np.array(predicted_momenta))
+
+    def test_step_rabi(self):
+        # test Rabi
+        rabi_matrix = dynq.NonadiabaticMatrix([[2.0, 1.0], [1.0, 3.0]])
+        rabi = dynq.potentials.MMSTHamiltonian(rabi_matrix)
+        rabi_topology = dynq.Topology(masses=[], potential=rabi)
+        rabi_snapshot = dynq.MMSTSnapshot(
+            coordinates=np.array([]), momenta=np.array([]),
+            electronic_coordinates=np.array([1.0, 0.0]),
+            electronic_momenta=np.array([0.0, 1.0]),
+            topology=rabi_topology
+        )
+        rabi_integ = CandyRozmus4MMST(0.01, rabi)
+        for i in range(10):
+            rabi_integ.step(rabi, rabi_snapshot, rabi_snapshot)
+
+        # NOTE: unverified -- these results are checked against the output
+        # that they first gave, not against any analytical results
+        assert_array_almost_equal(rabi_snapshot.electronic_coordinates,
+                                  np.array([1.07189698, 0.26951517]))
+        assert_array_almost_equal(rabi_snapshot.electronic_momenta,
+                                  np.array([-0.22220342, 0.85382907]))
+        assert_array_almost_equal(rabi_snapshot.coordinates, np.array([]))
+        assert_array_almost_equal(rabi_snapshot.momenta, np.array([]))
+
+
+    def test_step_tully(self):
+        # test Tully
         tully_V11 = pes.OneDimensionalInteractionModel(
             pes.interactions.TanhInteraction(a=1.6, V0=0.1)
         )
@@ -76,60 +127,30 @@ class testCandyRozmus4MMST(object):
         )
         tully_matrix = dynq.NonadiabaticMatrix([[tully_V11, tully_V12],
                                                 [tully_V12, tully_V22]])
-        self.tully = dynq.potentials.MMSTHamiltonian(tully_matrix)
+        tully = dynq.potentials.MMSTHamiltonian(tully_matrix)
         tully_topology = dynq.Topology(
             masses=np.array([1980.0]),
-            potential=self.tully
+            potential=tully
+        )
+        tully_snapshot = dynq.MMSTSnapshot(
+            coordinates=np.array([0.1]),
+            momenta=np.array([19.0]),
+            electronic_coordinates=np.array([0.7, 0.6]),
+            electronic_momenta=np.array([0.2, 0.1]),
+            topology=tully_topology
         )
 
-        self.tully_integ = CandyRozmus4MMST(1.0, self.tully)
 
-        uncoupled_matrix = dynq.NonadiabaticMatrix([[2.0, 0.0], [0.0, 3.0]])
-        self.uncoupled = dynq.potentials.MMSTHamiltonian(uncoupled_matrix)
+        tully_integ = CandyRozmus4MMST(1.0, tully)
+        tully_integ.step(tully, tully_snapshot, tully_snapshot)
 
-        rabi_matrix = dynq.NonadiabaticMatrix([[2.0, 1.0], [1.0, 3.0]])
-        self.rabi = dynq.potentials.MMSTHamiltonian(rabi_matrix)
-
-        pass
-
-    def test_cr4_step(self):
-        from math import sqrt
-        # test uncoupled
-        uncoupled_topology = dynq.Topology(masses=[], potential=self.uncoupled)
-        uncoupled_snap = dynq.MMSTSnapshot(
-            coordinates=np.array([]), momenta=np.array([]),
-            electronic_coordinates=np.array([1.0, 1.0]),
-            electronic_momenta=np.array([1.0, 1.0]),
-            topology=uncoupled_topology
-        )
-        uncoupled_integ = CandyRozmus4MMST(0.01, self.uncoupled)
-        for i in range(10):
-            uncoupled_integ.step(self.uncoupled, uncoupled_snap,
-                                 uncoupled_snap)
-
-        exact_1 = exact_ho(time=0.1, omega=2.0, m=1.0/2.0, q0=1.0, p0=1.0)
-        exact_2 = exact_ho(time=0.1, omega=3.0, m=1.0/3.0, q0=1.0, p0=1.0)
-        predicted_coordinates = [exact_1['q'][0], exact_2['q'][0]]
-        predicted_momenta = [exact_1['p'][0], exact_2['p'][0]]
-        assert_array_almost_equal(uncoupled_snap.electronic_coordinates,
-                                  np.array(predicted_coordinates))
-        assert_array_almost_equal(uncoupled_snap.electronic_momenta,
-                                  np.array(predicted_momenta))
-
-        # test Rabi
-        #rabi_topology = dynq.Topology(masses=[], potential=self.rabi)
-        #rabi_snapshot = dynq.MMSTSnapshot(
-            #coordinates=np.array([]), momenta=np.array([]),
-            #electronic_coordinates=np.array([1.0, 0.0]),
-            #electronic_momenta=np.array([0.0, 1.0]),
-            #topology=rabi_topology
-        #)
-        #rabi_integ = CandyRozmus4MMST(0.01, self.rabi)
-        #for i in range(10):
-            #rabi_integ.step(self.rabi, rabi_snapshot, rabi_snapshot)
-
-        # TODO: test results
-
-
-        # test Tully
-        raise SkipTest
+        # NOTE: unverified -- these results are checked against the output
+        # that they first gave, not against any analytical results
+        assert_array_almost_equal(tully_snapshot.coordinates,
+                                  np.array([0.10959396]))
+        assert_array_almost_equal(tully_snapshot.momenta,
+                                  np.array([18.9922916]))
+        assert_array_almost_equal(tully_snapshot.electronic_coordinates,
+                                  np.array([0.70714581, 0.6075074]))
+        assert_array_almost_equal(tully_snapshot.electronic_momenta,
+                                  np.array([0.15844469, 0.07522877]))

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -80,8 +80,40 @@ class testCandyRozmus4MMST(testCandyRozmus4):
             potential=self.tully
         )
 
-        self.integ = CandyRozmus4MMST(0.01, self.tully)
+        self.tully_integ = CandyRozmus4MMST(1.0, self.tully)
+
+        uncoupled_matrix = dynq.NonadiabaticMatrix([[2.0, 0.0], [0.0, 3.0]])
+        self.uncoupled = dynq.potentials.MMSTHamiltonian(uncoupled_matrix)
+
+        rabi_matrix = dynq.NonadiabaticMatrix([[2.0, 1.0], [1.0, 3.0]])
+        self.rabi = dynq.potentials.MMSTHamiltonian(rabi_matrix)
+        rabi_topology = dynq.Topology(masses=[], potential=self.rabi)
+        self.rabi_snapshot = dynq.MMSTSnapshot(
+            coordinates=[], momenta=[],
+            electronic_coordinates=np.array([1.0, 0.0]),
+            electronic_momenta=np.array([0.0, 1.0]),
+            topology=rabi_topology
+        )
+        self.rabi_integ = CandyRozmus4MMST(0.1, self.rabi)
+
         pass
 
     def test_cr4_step(self):
+        # test uncoupled
+        uncoupled_topology = dynq.Topology(masses=[], potential=self.uncoupled)
+        uncoupled_snap = dynq.MMSTSnapshot(
+            coordinates=np.array([]), momenta=np.array([]),
+            electronic_coordinates=np.array([1.0, 0.0]),
+            electronic_momenta=np.array([0.0, 1.0]),
+            topology=uncoupled_topology
+        )
+        uncoupled_integ = CandyRozmus4MMST(0.1, self.uncoupled)
+        for i in range(10):
+            uncoupled_integ.step(self.uncoupled, uncoupled_snap,
+                                 uncoupled_snap)
+
+
+        # test Rabi
+
+        # test Tully
         raise SkipTest

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -26,7 +26,7 @@ class testCandyRozmus4(object):
         x0 = self.ho.x0
         p0 = initial_snap.momenta[0]
         q0 = initial_snap.coordinates[0]
-        return exact_ho(omega, m, p0, q0, x0, time)
+        return exact_ho(time, omega, m, p0, q0, x0)
 
         #cos_wt = np.cos(omega*time)
         #sin_wt = np.sin(omega*time)
@@ -63,7 +63,7 @@ class testCandyRozmus4(object):
         assert_array_almost_equal(new_snap.coordinates, exact_0x10['q'])
         assert_array_almost_equal(new_snap.momenta, exact_0x10['p'])
 
-class testCandyRozmus4MMST(testCandyRozmus4):
+class testCandyRozmus4MMST(object):
     def setup(self):
         tully_V11 = pes.OneDimensionalInteractionModel(
             pes.interactions.TanhInteraction(a=1.6, V0=0.1)
@@ -89,14 +89,6 @@ class testCandyRozmus4MMST(testCandyRozmus4):
 
         rabi_matrix = dynq.NonadiabaticMatrix([[2.0, 1.0], [1.0, 3.0]])
         self.rabi = dynq.potentials.MMSTHamiltonian(rabi_matrix)
-        rabi_topology = dynq.Topology(masses=[], potential=self.rabi)
-        self.rabi_snapshot = dynq.MMSTSnapshot(
-            coordinates=[], momenta=[],
-            electronic_coordinates=np.array([1.0, 0.0]),
-            electronic_momenta=np.array([0.0, 1.0]),
-            topology=rabi_topology
-        )
-        self.rabi_integ = CandyRozmus4MMST(0.1, self.rabi)
 
         pass
 
@@ -125,6 +117,19 @@ class testCandyRozmus4MMST(testCandyRozmus4):
                                   np.array(predicted_momenta))
 
         # test Rabi
+        #rabi_topology = dynq.Topology(masses=[], potential=self.rabi)
+        #rabi_snapshot = dynq.MMSTSnapshot(
+            #coordinates=np.array([]), momenta=np.array([]),
+            #electronic_coordinates=np.array([1.0, 0.0]),
+            #electronic_momenta=np.array([0.0, 1.0]),
+            #topology=rabi_topology
+        #)
+        #rabi_integ = CandyRozmus4MMST(0.01, self.rabi)
+        #for i in range(10):
+            #rabi_integ.step(self.rabi, rabi_snapshot, rabi_snapshot)
+
+        # TODO: test results
+
 
         # test Tully
         raise SkipTest

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -101,6 +101,7 @@ class testCandyRozmus4MMST(testCandyRozmus4):
         pass
 
     def test_cr4_step(self):
+        from math import sqrt
         # test uncoupled
         uncoupled_topology = dynq.Topology(masses=[], potential=self.uncoupled)
         uncoupled_snap = dynq.MMSTSnapshot(
@@ -109,19 +110,19 @@ class testCandyRozmus4MMST(testCandyRozmus4):
             electronic_momenta=np.array([1.0, 1.0]),
             topology=uncoupled_topology
         )
-        uncoupled_integ = CandyRozmus4MMST(0.1, self.uncoupled)
+        uncoupled_integ = CandyRozmus4MMST(0.01, self.uncoupled)
         for i in range(10):
             uncoupled_integ.step(self.uncoupled, uncoupled_snap,
                                  uncoupled_snap)
 
-        exact_1 = exact_ho(time=1.0, omega=2.0, m=1.0, q0=1.0, p0=1.0)
-        exact_2 = exact_ho(time=1.0, omega=3.0, m=1.0, q0=1.0, p0=1.0)
+        exact_1 = exact_ho(time=0.1, omega=2.0, m=1.0/2.0, q0=1.0, p0=1.0)
+        exact_2 = exact_ho(time=0.1, omega=3.0, m=1.0/3.0, q0=1.0, p0=1.0)
         predicted_coordinates = [exact_1['q'][0], exact_2['q'][0]]
         predicted_momenta = [exact_1['p'][0], exact_2['p'][0]]
-        print predicted_momenta, predicted_coordinates
-        print uncoupled_snap.electronic_momenta, uncoupled_snap.electronic_coordinates
-        #assert_array_almost_equal(uncoupled_snap.electronic_coordinates,
-                                  #np.array(predicted_coordinates))
+        assert_array_almost_equal(uncoupled_snap.electronic_coordinates,
+                                  np.array(predicted_coordinates))
+        assert_array_almost_equal(uncoupled_snap.electronic_momenta,
+                                  np.array(predicted_momenta))
 
         # test Rabi
 

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -25,14 +25,16 @@ class testCandyRozmus4(object):
         omega = np.sqrt(self.ho.k / m)
         x0 = self.ho.x0
         p0 = initial_snap.momenta[0]
-        q0 = initial_snap.coordinates[0] - x0
-        cos_wt = np.cos(omega*time)
-        sin_wt = np.sin(omega*time)
-        state_at_t = {
-            'q' : np.array([q0*cos_wt + p0/m/omega*sin_wt + x0]),
-            'p' : np.array([p0*cos_wt - q0*m*omega*sin_wt])
-        }
-        return state_at_t
+        q0 = initial_snap.coordinates[0]
+        return exact_ho(omega, m, p0, q0, x0, time)
+
+        #cos_wt = np.cos(omega*time)
+        #sin_wt = np.sin(omega*time)
+        #state_at_t = {
+            #'q' : np.array([q0*cos_wt + p0/m/omega*sin_wt + x0]),
+            #'p' : np.array([p0*cos_wt - q0*m*omega*sin_wt])
+        #}
+        #return state_at_t
 
     def test_cr4_step(self):
         new_snap = dynq.Snapshot(coordinates=np.array([0.0]),
@@ -103,8 +105,8 @@ class testCandyRozmus4MMST(testCandyRozmus4):
         uncoupled_topology = dynq.Topology(masses=[], potential=self.uncoupled)
         uncoupled_snap = dynq.MMSTSnapshot(
             coordinates=np.array([]), momenta=np.array([]),
-            electronic_coordinates=np.array([1.0, 0.0]),
-            electronic_momenta=np.array([0.0, 1.0]),
+            electronic_coordinates=np.array([1.0, 1.0]),
+            electronic_momenta=np.array([1.0, 1.0]),
             topology=uncoupled_topology
         )
         uncoupled_integ = CandyRozmus4MMST(0.1, self.uncoupled)
@@ -112,6 +114,14 @@ class testCandyRozmus4MMST(testCandyRozmus4):
             uncoupled_integ.step(self.uncoupled, uncoupled_snap,
                                  uncoupled_snap)
 
+        exact_1 = exact_ho(time=1.0, omega=2.0, m=1.0, q0=1.0, p0=1.0)
+        exact_2 = exact_ho(time=1.0, omega=3.0, m=1.0, q0=1.0, p0=1.0)
+        predicted_coordinates = [exact_1['q'][0], exact_2['q'][0]]
+        predicted_momenta = [exact_1['p'][0], exact_2['p'][0]]
+        print predicted_momenta, predicted_coordinates
+        print uncoupled_snap.electronic_momenta, uncoupled_snap.electronic_coordinates
+        #assert_array_almost_equal(uncoupled_snap.electronic_coordinates,
+                                  #np.array(predicted_coordinates))
 
         # test Rabi
 

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -3,6 +3,7 @@ import numpy as np
 from tools import *
 
 from dynamiq_engine.integrators.candy_rozmus_4 import *
+import dynamiq_engine.potentials as pes
 
 class testCandyRozmus4(object):
     def setup(self):
@@ -59,3 +60,28 @@ class testCandyRozmus4(object):
         exact_0x10 = self.exact_ho(snap1, 0.10)
         assert_array_almost_equal(new_snap.coordinates, exact_0x10['q'])
         assert_array_almost_equal(new_snap.momenta, exact_0x10['p'])
+
+class testCandyRozmus4MMST(testCandyRozmus4):
+    def setup(self):
+        tully_V11 = pes.OneDimensionalInteractionModel(
+            pes.interactions.TanhInteraction(a=1.6, V0=0.1)
+        )
+        tully_V22 = pes.OneDimensionalInteractionModel(
+            pes.interactions.TanhInteraction(a=1.6, V0=-0.1)
+        )
+        tully_V12 = pes.OneDimensionalInteractionModel(
+            pes.interactions.GaussianInteraction(A=0.05, alpha=1.0)
+        )
+        tully_matrix = dynq.NonadiabaticMatrix([[tully_V11, tully_V12],
+                                                [tully_V12, tully_V22]])
+        self.tully = dynq.potentials.MMSTHamiltonian(tully_matrix)
+        tully_topology = dynq.Topology(
+            masses=np.array([1980.0]),
+            potential=self.tully
+        )
+
+        self.integ = CandyRozmus4MMST(0.01, self.tully)
+        pass
+
+    def test_cr4_step(self):
+        raise SkipTest

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -9,6 +9,7 @@ class testMMSTHamiltonian(object):
     def setup(self):
         tully_V11 = pes.interactions.TanhInteraction(a=1.6, V0=0.1)
         tully_V22 = pes.interactions.TanhInteraction(a=1.6, V0=-0.1)
+        tully_V12 = pes.interactions.GaussianInteraction(A=0.05, alpha=1.0)
         pass
 
     def test_H(self):

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -10,7 +10,32 @@ class testMMSTHamiltonian(object):
         tully_V11 = pes.interactions.TanhInteraction(a=1.6, V0=0.1)
         tully_V22 = pes.interactions.TanhInteraction(a=1.6, V0=-0.1)
         tully_V12 = pes.interactions.GaussianInteraction(A=0.05, alpha=1.0)
+        tully_matrix = dynq.NonadiabaticMatrix([[tully_V11, tully_V12],
+                                                [tully_V12, tully_V22]])
+        self.tully = MMSTHamiltonian(tully_matrix)
+        self.tully_snap = dynq.MMSTSnapshot(
+            coordinates=np.array([0.1]),
+            momenta=np.array([19.0]),
+            electronic_coordinates=np.array([0.7, 0.6]),
+            electronic_momenta=np.array([0.2, 0.1])
+            # can we get away with no topology?
+        )
+        # tully_V11(tully_snap) = 
+        # tully_V12(tully_snap) = 
+        # tully_V22(tully_snap) = 
+
+        #four_state_matrix = dynq.NonadiabaticMatrix()
+        #four_state = MMSTHamiltonian(four_state_matrix)
+        #four_state_snap = 
         pass
+
+    def test_elect_cache(self):
+        tully_elect = self.tully._elect_cache(self.tully_snap)
+        assert_almost_equal(tully_elect[(0,0)], 0.5*(0.7*0.7 + 0.2*0.2 - 1.0))
+        assert_almost_equal(tully_elect[(1,1)], 0.5*(0.6*0.6 + 0.1*0.1 - 1.0))
+        assert_almost_equal(tully_elect[(0,1)], 0.7*0.6 + 0.2*0.1)
+        if (1,0) in tully_elect.keys():
+            raise AssertionError("Unexpected key in MMSTHamiltonian._elect")
 
     def test_H(self):
         pass

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -1,0 +1,31 @@
+import dynamiq_engine as dynq
+import dynamiq_engine.potentials as pes
+import numpy as np
+from tools import *
+
+from dynamiq_engine.potentials.mmst_hamiltonian import *
+
+class testMMSTHamiltonian(object):
+    def setup(self):
+        tully_V11 = pes.interactions.TanhInteraction(a=1.6, V0=0.1)
+        tully_V22 = pes.interactions.TanhInteraction(a=1.6, V0=-0.1)
+        pass
+
+    def test_H(self):
+        pass
+
+    def test_V(self):
+        pass
+
+    def test_set_dHdq(self):
+        pass
+
+    def test_set_dHdp(self):
+        pass
+
+    def test_set_electonic_dHdq(self):
+        pass
+
+    def test_set_electonic_dHdp(self):
+        pass
+

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -7,22 +7,34 @@ from dynamiq_engine.potentials.mmst_hamiltonian import *
 
 class testMMSTHamiltonian(object):
     def setup(self):
-        tully_V11 = pes.interactions.TanhInteraction(a=1.6, V0=0.1)
-        tully_V22 = pes.interactions.TanhInteraction(a=1.6, V0=-0.1)
-        tully_V12 = pes.interactions.GaussianInteraction(A=0.05, alpha=1.0)
+        tully_V11 = pes.OneDimensionalInteractionModel(
+            pes.interactions.TanhInteraction(a=1.6, V0=0.1)
+        )
+        tully_V22 = pes.OneDimensionalInteractionModel(
+            pes.interactions.TanhInteraction(a=1.6, V0=-0.1)
+        )
+        tully_V12 = pes.OneDimensionalInteractionModel(
+            pes.interactions.GaussianInteraction(A=0.05, alpha=1.0)
+        )
         tully_matrix = dynq.NonadiabaticMatrix([[tully_V11, tully_V12],
                                                 [tully_V12, tully_V22]])
         self.tully = MMSTHamiltonian(tully_matrix)
+        tully_topology = dynq.Topology(
+            masses=np.array([1.0]),
+            potential=tully_V11 #TODO: don't pick an arbitrary one...
+        )
+
         self.tully_snap = dynq.MMSTSnapshot(
             coordinates=np.array([0.1]),
             momenta=np.array([19.0]),
             electronic_coordinates=np.array([0.7, 0.6]),
-            electronic_momenta=np.array([0.2, 0.1])
-            # can we get away with no topology?
+            electronic_momenta=np.array([0.2, 0.1]),
+            topology=tully_topology
         )
-        # tully_V11(tully_snap) = 
-        # tully_V12(tully_snap) = 
-        # tully_V22(tully_snap) = 
+        # tully_V11(tully_snap) = 0.1*tanh(1.6*0.1) = 0.0158648504297499
+        # tully_V12(tully_snap) = 0.05*exp(-1.0*(0.1-0.0)^2) 
+        #                       = 0.0495024916874584
+        # tully_V22(tully_snap) = -0.0158648504297499
 
         #four_state_matrix = dynq.NonadiabaticMatrix()
         #four_state = MMSTHamiltonian(four_state_matrix)
@@ -31,17 +43,21 @@ class testMMSTHamiltonian(object):
 
     def test_elect_cache(self):
         tully_elect = self.tully._elect_cache(self.tully_snap)
-        assert_almost_equal(tully_elect[(0,0)], 0.5*(0.7*0.7 + 0.2*0.2 - 1.0))
-        assert_almost_equal(tully_elect[(1,1)], 0.5*(0.6*0.6 + 0.1*0.1 - 1.0))
-        assert_almost_equal(tully_elect[(0,1)], 0.7*0.6 + 0.2*0.1)
+        # tully_elect[(0,0)] == 0.5*(0.7*0.7 + 0.2*0.2 - 1.0) = -0.235
+        # tully_elect[(1,1)] == 0.5*(0.6*0.6 + 0.1*0.1 - 1.0) = -0.315
+        # tully_elect[(0,1)] == 0.7*0.6 + 0.2*0.1 = 0.44
+        assert_almost_equal(tully_elect[(0,0)], -0.235)
+        assert_almost_equal(tully_elect[(1,1)], -0.315)
+        assert_almost_equal(tully_elect[(0,1)], 0.44)
         if (1,0) in tully_elect.keys():
             raise AssertionError("Unexpected key in MMSTHamiltonian._elect")
 
-    def test_H(self):
-        pass
-
     def test_V(self):
-        pass
+        # V =  -0.235 * 0.0158648504297499 # V11
+        #      -0.315 * -0.0158648504297499 # V22
+        #      + 0.44 * 0.0495024916874584 # V12 
+        #   = 0.0230502843768617
+        assert_almost_equal(self.tully.V(self.tully_snap), 0.0230502843768617)
 
     def test_set_dHdq(self):
         pass

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -131,6 +131,14 @@ class testMMSTHamiltonian(object):
         assert_array_almost_equal(self.tully.electronic_dHdq(self.tully_snap),
                                   np.array([0.0408068903133000,
                                             0.0251328339233709]))
+        # dHdx0 = 0.00*0.5 + 1.00*0.6 + 0.75*0.7 + 0.00*0.8 = 1.125
+        # dHdx1 = 1.00*0.5 + 1.50*0.6 + 0.00*0.7 + 1.50*0.8 = 2.60
+        # dHdx2 = 0.75*0.5 + 0.00*0.6 + 0.50*0.7 + 2.00*0.8 = 2.325
+        # dHdx3 = 0.00*0.5 + 1.50*0.6 + 2.00*0.7 + -1.0*0.8 = 1.5
+        assert_array_almost_equal(
+            self.four_state.electronic_dHdq(self.four_state_snap),
+            np.array([1.125, 2.6, 2.325, 1.5])
+        )
 
     def test_electronic_dHdp(self):
         # dHdp1 = V11*p1 + V12*p2
@@ -142,5 +150,13 @@ class testMMSTHamiltonian(object):
         assert_array_almost_equal(self.tully.electronic_dHdp(self.tully_snap),
                                   np.array([0.00812321925469582,
                                             0.00831401329451669]))
-        pass
+        # dHdp0 = 0.00*0.1 + 1.00*0.2 + 0.75*0.3 + 0.00*0.4 = 0.425
+        # dHdp1 = 1.00*0.1 + 1.50*0.2 + 0.00*0.3 + 1.50*0.4 = 1.0
+        # dHdp2 = 0.75*0.1 + 0.00*0.2 + 0.50*0.3 + 2.00*0.4 = 1.025
+        # dHdp3 = 0.00*0.1 + 1.50*0.2 + 2.00*0.3 + -1.0*0.4 = 0.5
+        assert_array_almost_equal(
+            self.four_state.electronic_dHdp(self.four_state_snap),
+            np.array([0.425, 1.0, 1.025, 0.5])
+        )
+
 

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -92,6 +92,14 @@ class testMMSTHamiltonian(object):
         #      + 0.44 * 0.0495024916874584 # V12 
         #   = 0.0230502843768617
         assert_almost_equal(self.tully.V(self.tully_snap), 0.0230502843768617)
+        
+        # V =  -0.37*0.00 + 0.32*1.00 + 0.38*0.75 + 0.44*0.00
+        #                 - 0.30*1.50 + 0.48*0.00 + 0.56*1.50
+        #                             - 0.21*0.50 + 0.68*2.00
+        #                                         - 0.10*-1.00
+        #   = 2.35
+        assert_almost_equal(self.four_state.V(self.four_state_snap), 2.35)
+        
 
     def test_dHdq(self):
         # dV11dx = 0.155972904333467
@@ -104,10 +112,14 @@ class testMMSTHamiltonian(object):
         #      = 0.00812161307818102
         assert_array_almost_equal(self.tully.dHdq(self.tully_snap),
                                   0.00812161307818102)
+        assert_array_almost_equal(self.four_state.dHdq(self.four_state_snap),
+                                  np.array([]))
 
     def test_dHdp(self):
         assert_array_almost_equal(self.tully.dHdp(self.tully_snap), 
                                   np.array([19.0/1980.0]))
+        assert_array_almost_equal(self.four_state.dHdp(self.four_state_snap),
+                                  np.array([]))
 
     def test_electronic_dHdq(self):
         # dHdx1 = V11*x1 + V12*x2

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -75,9 +75,26 @@ class testMMSTHamiltonian(object):
         assert_array_almost_equal(self.tully.dHdp(self.tully_snap), 
                                   np.array([19.0/1980.0]))
 
-    def test_electonic_dHdq(self):
-        pass
+    def test_electronic_dHdq(self):
+        # dHdx1 = V11*x1 + V12*x2
+        #       = 0.0158648504297499 * 0.7 + 0.0495024916874584 * 0.6
+        #       = 0.0408068903133000
+        # dHdx2 = V22*x2 + V12*x1
+        #       = -0.0158648504297499 * 0.6 + 0.0495024916874584 * 0.7
+        #       = 0.0251328339233709
+        assert_array_almost_equal(self.tully.electronic_dHdq(self.tully_snap),
+                                  np.array([0.0408068903133000,
+                                            0.0251328339233709]))
 
-    def test_electonic_dHdp(self):
+    def test_electronic_dHdp(self):
+        # dHdp1 = V11*p1 + V12*p2
+        #       = 0.0158648504297499 * 0.2 + 0.0495024916874584 * 0.1
+        #       = 0.00812321925469582
+        # dHdp2 = V22*p2 + V12*p1
+        #       = -0.0158648504297499 * 0.1 + 0.0495024916874584 * 0.2
+        #       = 0.00831401329451669
+        assert_array_almost_equal(self.tully.electronic_dHdp(self.tully_snap),
+                                  np.array([0.00812321925469582,
+                                            0.00831401329451669]))
         pass
 

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -20,7 +20,7 @@ class testMMSTHamiltonian(object):
                                                 [tully_V12, tully_V22]])
         self.tully = MMSTHamiltonian(tully_matrix)
         tully_topology = dynq.Topology(
-            masses=np.array([1.0]),
+            masses=np.array([1980.0]),
             potential=tully_V11 #TODO: don't pick an arbitrary one...
         )
 
@@ -59,15 +59,25 @@ class testMMSTHamiltonian(object):
         #   = 0.0230502843768617
         assert_almost_equal(self.tully.V(self.tully_snap), 0.0230502843768617)
 
-    def test_set_dHdq(self):
+    def test_dHdq(self):
+        # dV11dx = 0.155972904333467
+        # dV22dx = -0.155972904333467
+        # dV12dx = -0.00990049833749168
+        # dHdq =  dV11dx*elect_11 + dV22dx*elect_22 + dV12dx*elect_12
+        #      =   0.155972904333467 * -0.235
+        #        -0.155972904333467 * -0.315
+        #        -0.00990049833749168 * 0.44
+        #      = 0.00812161307818102
+        assert_array_almost_equal(self.tully.dHdq(self.tully_snap),
+                                  0.00812161307818102)
+
+    def test_dHdp(self):
+        assert_array_almost_equal(self.tully.dHdp(self.tully_snap), 
+                                  np.array([19.0/1980.0]))
+
+    def test_electonic_dHdq(self):
         pass
 
-    def test_set_dHdp(self):
-        pass
-
-    def test_set_electonic_dHdq(self):
-        pass
-
-    def test_set_electonic_dHdp(self):
+    def test_electonic_dHdp(self):
         pass
 

--- a/dynamiq_engine/tests/test_pairwise_interactions.py
+++ b/dynamiq_engine/tests/test_pairwise_interactions.py
@@ -151,3 +151,36 @@ class testQuarticInteraction(object):
             2.0 : 55.75
         }
         check_function(self.quartic.d2fdx2, tests)
+
+class testGaussianInteraction(object):
+    def setup(self):
+        self.gaussian = GaussianInteraction(A=2.0, alpha=0.25, x0=0.5)
+
+    def test_f(self):
+        tests = {
+            0.0 : 1.87882612562695,
+            0.5 : 2.0,
+            1.0 : 1.87882612562695,
+            2.0 : 1.13956564946185
+        }
+        check_function(self.gaussian.f, tests)
+        check_function(self.gaussian, tests)
+
+    def test_dfdx(self):
+        tests = {
+            0.0 : 0.469706531406738,
+            0.5 : 0.0,
+            1.0 : -0.469706531406738,
+            2.0 : -0.854674237096384
+        }
+        check_function(self.gaussian.dfdx, tests)
+
+    def test_d2fdx2(self):
+        tests = {
+            0.0 : -0.821986429961791,
+            0.5 : -1.0,
+            1.0 : -0.821986429961791,
+            2.0 : 0.0712228530913653
+        }
+        check_function(self.gaussian.d2fdx2, tests)
+

--- a/dynamiq_engine/tests/tools.py
+++ b/dynamiq_engine/tests/tools.py
@@ -5,6 +5,7 @@ from nose.tools import (
 from nose.plugins.skip import Skip, SkipTest
 
 from numpy.testing import assert_array_almost_equal
+import numpy as np
 
 def check_function(function, dictionary):
     """Test a single-variable function based on key-value pairs.
@@ -14,3 +15,12 @@ def check_function(function, dictionary):
     """
     for test_input in dictionary.keys():
         assert_almost_equal(function(test_input), dictionary[test_input])
+
+def exact_ho(time, omega, m, p0, q0, x0=0.0):
+    cos_wt = np.cos(omega*time)
+    sin_wt = np.sin(omega*time)
+    state_at_t = {
+        'q' : np.array([(q0-x0)*cos_wt + p0/m/omega*sin_wt + x0]),
+        'p' : np.array([p0*cos_wt - (q0-x0)*m*omega*sin_wt])
+    }
+    return state_at_t


### PR DESCRIPTION
MMST for basic dynamics (before monodromy/action propagation).

The approach we'll use is to create new snapshot features for electronic variables (and therefore a new type of snapshot for MMST). This allows us to reuse the existing nuclear potential energy surfaces without any modification.

This does mean that the we need separate integrators for the MMST. That much is actually to be expected -- after all, we lose the symplectic property of many integrators if we apply them to an MMST Hamiltonian.

- [x] Add new snapshot features for electronic degrees of freedom
- [x] Add new integrator that can propagate electronic degrees of freedom
- [x] Draft MMST potential
- [x] Tests for MMST potential with Tully model
- [x] Tests for MMST potential with four-state model
- [x] Test uncoupled MMST with MMST-ready integrator (part-integration)
- [x] Test Rabi oscillations with MMST-ready integrator (part-integration)
- [x] Test Tully model MMST with MMST-ready integrator (part-integration)


The part-integration tests will show that we get the right behavior for a few steps in simple models.