### PR TITLE
Calculate action in CandyRozmus4

### DIFF
--- a/dynamiq_engine/dynamiq_engine_core.py
+++ b/dynamiq_engine/dynamiq_engine_core.py
@@ -22,6 +22,7 @@ class Snapshot(paths.AbstractSnapshot):
         self.topology = topology
         self.is_reversed = is_reversed
         # set monodromy matrices and action value
+        self._action = None
         if monodromy is not None:
             self._Mqq = monodromy[0]
             self._Mqp = monodromy[1]
@@ -81,6 +82,17 @@ class MMSTSnapshot(Snapshot):
         )
         self.electronic_coordinates = electronic_coordinates
         self.electronic_momenta = electronic_momenta
+
+    def copy(self):
+        new_snap = MMSTSnapshot(
+            coordinates=self.coordinates.copy(),
+            momenta=self.momenta.copy(),
+            electronic_coordinates=self.electronic_coordinates.copy(),
+            electronic_momenta=self.electronic_momenta.copy(),
+            is_reversed=self.is_reversed,
+            topology=self.topology
+        )
+        return new_snap
 
 
 class Topology(paths.Topology):

--- a/dynamiq_engine/features/__init__.py
+++ b/dynamiq_engine/features/__init__.py
@@ -1,3 +1,4 @@
 import momenta
 import electronic_momenta
 import electronic_coordinates
+import action

--- a/dynamiq_engine/features/action.py
+++ b/dynamiq_engine/features/action.py
@@ -1,0 +1,3 @@
+_variables = ['action']
+
+# TODO: include storage later

--- a/dynamiq_engine/integrators/candy_rozmus_4.py
+++ b/dynamiq_engine/integrators/candy_rozmus_4.py
@@ -30,31 +30,99 @@ class CandyRozmus4(Integrator):
         self.local_dHdp = np.zeros(n_spatial * n_atoms)
 
     def prepare(self, feature_list):
-        pass
+        import dynamiq_engine.features as dynq_f
+        import openpathsampling.features as paths_f
+        self.feature_list = feature_list
+        supported_features = [
+            paths_f.coordinates,
+            dynq_f.momenta,
+            dynq_f.action,
+            dynq_f.electronic_coordinates,
+            dynq_f.electronic_momenta
+            # TODO: add support for monodromy or for prefactor
+        ]
+        for f in self.feature_list:
+            if f not in supported_features:
+                raise RuntimeError("Feature " + str(f) + 
+                                   " not supported by this integrator")
+        
+        # Two potential approaches: either we build the `update` function
+        # here, or we have a bunch of if-statements in the main `step`
+        # function. Either way, we have the option here of overriding `step`
+        # with a customized, faster version based on the `feature_list`.
+
+        pre_step = []
+        pre_momentum = []
+        post_momentum = []
+        pre_position = []
+        post_position = []
+        post_step = []
+        momentum = [self.momentum_calculate, self.momentum_update]
+        position = [self.position_calculate, self.position_update]
+
+
+        if dynq_f.electronic_momenta in self.feature_list:
+            pre_momentum.append(self.electronic_momentum_calculate)
+            post_momentum.append(self.electronic_momentum_update)
+
+        if dynq_f.electronic_coordinates in self.feature_list:
+            pre_position.append(self.electronic_position_calculate)
+            post_position.append(self.electronic_position_update)
+
+        if dynq_f.action in self.feature_list:
+            post_momentum.append(self.action_step)
+
+        self.update_steps = (pre_step 
+                             + pre_momentum + momentum + post_momentum 
+                             + pre_position + position + post_position 
+                             + post_step)
 
     def reset(self):
         pass
 
-    def momentum_update(self, potential, snap, k):
+    def momentum_calculate(self, potential, snap, k):
         potential.set_dHdq(self.local_dHdq, snap)
         self.local_dHdq *= self._b_k[k]
+
+    def momentum_update(self, potential, snap, k):
         np.subtract(snap.momenta, self.local_dHdq, snap.momenta)
 
-    def position_update(self, potential, snap, k):
+    def electronic_momentum_calculate(self, potential, snap, k):
+        potential.set_electronic_dHdq(self.local_electronic_dHdq, snap)
+        self.local_electronic_dHdq *= self._b_k[k]
+
+    def electronic_momentum_update(self, potential, snap, k):
+        np.subtract(snap.electronic_momenta, self.local_electronic_dHdq,
+                    snap.electronic_momenta)
+
+    def position_calculate(self, potential, snap, k):
         potential.set_dHdp(self.local_dHdp, snap)
         self.local_dHdp *=  self._a_k[k]
+
+    def position_update(self, potential, snap, k):
         np.add(snap.coordinates, self.local_dHdp, snap.coordinates)
 
+    def electronic_position_calculate(self, potential, snap, k):
+        potential.set_electronic_dHdp(self.local_electronic_dHdp, snap)
+        self.local_electronic_dHdp *= self._a_k[k]
+
+    def electronic_position_update(self, potential, snap, k):
+        np.add(snap.electronic_coordinates, self.local_electronic_dHdp, 
+               snap.electronic_coordinates)
+
+
     def action_step(self, potential, snap, new_snap, k):
-        self.localS += self._a_k[k]*potential.T(snap) 
-        self.localS -= self._b_k[k]*potential.V(snap)
+        self.local_S += self._a_k[k]*potential.T(snap) 
+        self.local_S -= self._b_k[k]*potential.V(snap)
 
     def step(self, potential, old_snap, new_snap):
         new_snap.copy_from(old_snap)
         for k in range(4):
-            self.momentum_update(potential, new_snap, k)
+            for update in self.update_steps:
+                update(potential, new_snap, k)
+            #self.momentum_update(potential, new_snap, k)
             # TODO: monodromy and action
-            self.position_update(potential, new_snap, k)
+            #self.position_update(potential, new_snap, k)
         # wrap PBCs if necessary
 
 class CandyRozmus4MMST(CandyRozmus4):
@@ -62,24 +130,12 @@ class CandyRozmus4MMST(CandyRozmus4):
         super(CandyRozmus4MMST, self).__init__(dt, potential, n_frames)
         self.local_electronic_dHdp = np.zeros(potential.n_electronic_states)
         self.local_electronic_dHdq = np.zeros(potential.n_electronic_states)
+        import dynamiq_engine.features as dynq_f
+        import openpathsampling.features as paths_f
+        self.prepare([paths_f.coordinates, dynq_f.momenta,
+                      dynq_f.electronic_coordinates,
+                      dynq_f.electronic_momenta])
     
-    def position_update(self, potential, snap, k):
-        potential.set_dHdp(self.local_dHdp, snap)
-        self.local_dHdp *=  self._a_k[k]
-        potential.set_electronic_dHdp(self.local_electronic_dHdp, snap)
-        self.local_electronic_dHdp *= self._a_k[k]
-        np.add(snap.coordinates, self.local_dHdp, snap.coordinates)
-        np.add(snap.electronic_coordinates, self.local_electronic_dHdp, 
-               snap.electronic_coordinates)
-
-    def momentum_update(self, potential, snap, k):
-        potential.set_dHdq(self.local_dHdq, snap)
-        self.local_dHdq *= self._b_k[k]
-        potential.set_electronic_dHdq(self.local_electronic_dHdq, snap)
-        self.local_electronic_dHdq *= self._b_k[k]
-        np.subtract(snap.momenta, self.local_dHdq, snap.momenta)
-        np.subtract(snap.electronic_momenta, self.local_electronic_dHdq,
-                    snap.electronic_momenta)
 
 # to be done later
 class CandyRozmus4Monodromy(CandyRozmus4):

--- a/dynamiq_engine/integrators/candy_rozmus_4.py
+++ b/dynamiq_engine/integrators/candy_rozmus_4.py
@@ -29,6 +29,12 @@ class CandyRozmus4(Integrator):
         self.local_dHdq = np.zeros(n_spatial * n_atoms)
         self.local_dHdp = np.zeros(n_spatial * n_atoms)
 
+    def prepare(self, feature_list):
+        pass
+
+    def reset(self):
+        pass
+
     def momentum_update(self, potential, snap, k):
         potential.set_dHdq(self.local_dHdq, snap)
         self.local_dHdq *= self._b_k[k]
@@ -39,8 +45,9 @@ class CandyRozmus4(Integrator):
         self.local_dHdp *=  self._a_k[k]
         np.add(snap.coordinates, self.local_dHdp, snap.coordinates)
 
-    def action_step(self, potential, old_snap, new_snap, k):
-        pass
+    def action_step(self, potential, snap, new_snap, k):
+        self.localS += self._a_k[k]*potential.T(snap) 
+        self.localS -= self._b_k[k]*potential.V(snap)
 
     def step(self, potential, old_snap, new_snap):
         new_snap.copy_from(old_snap)

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -115,7 +115,7 @@ class MMSTHamiltonian(PotentialEnergySurface):
     def T(self, snapshot):
         """ T = L + V, such that L = T - V
         
-        Since $L = P \dot{q} - H$, with $\dot{q} = -dH/dp$, and $dHdp$
+        Since $L = P \dot{q} - H$, with $\dot{q} = dH/dp$, and $dHdp$
         includes both $p$ and $q$, this gets a little more complicated than
         the normal non-MMST implementation.
         """

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -113,9 +113,24 @@ class MMSTHamiltonian(PotentialEnergySurface):
     # dHdp (for nuclear only) is still the same
 
     # following are to be done later
-    def T(self, snap):
-        """ T = L + V, such that L = T - V"""
-        pass
+    def T(self, snapshot):
+        """ T = L + V, such that L = T - V
+        
+        Since $L = P \dot{q} - H$, with $\dot{q} = -dH/dp$, and $dHdp$
+        includes both $p$ and $q$, this gets a little more complicated than
+        the normal non-MMST implementation.
+        """
+        V_ij = self.H_matrix.numeric_matrix(snapshot)
+
+        T = self.kinetic_energy(snapshot)
+        for i in range(self.n_electronic_states):
+            p_i = snapshot.electronic_momenta[i]
+            T += V_ij[(i,i)]
+            for j in range(i+1, self.n_electronic_states):
+                p_j = snapshot.electronic_momenta[j]
+                T = 2 * V_ij[(i,j)] * p_i * p_j
+
+        return T
 
     def L(self, snap):
         pass

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -113,6 +113,10 @@ class MMSTHamiltonian(PotentialEnergySurface):
     # dHdp (for nuclear only) is still the same
 
     # following are to be done later
+    def T(self, snap):
+        """ T = L + V, such that L = T - V"""
+        pass
+
     def L(self, snap):
         pass
 

--- a/dynamiq_engine/potentials/mmst_hamiltonian.py
+++ b/dynamiq_engine/potentials/mmst_hamiltonian.py
@@ -110,9 +110,8 @@ class MMSTHamiltonian(PotentialEnergySurface):
         self.set_electronic_dHdq(e_dHdq, snapshot)
         return e_dHdq
 
-    # dHdp (for nuclear only) is still the same
+    # dHdp (for nuclear only) is still the same as standard
 
-    # following are to be done later
     def T(self, snapshot):
         """ T = L + V, such that L = T - V
         
@@ -125,15 +124,12 @@ class MMSTHamiltonian(PotentialEnergySurface):
         T = self.kinetic_energy(snapshot)
         for i in range(self.n_electronic_states):
             p_i = snapshot.electronic_momenta[i]
-            T += V_ij[(i,i)]
+            T += V_ij[(i,i)] * p_i * p_i
             for j in range(i+1, self.n_electronic_states):
                 p_j = snapshot.electronic_momenta[j]
-                T = 2 * V_ij[(i,j)] * p_i * p_j
+                T += 2 * V_ij[(i,j)] * p_i * p_j
 
         return T
-
-    def L(self, snap):
-        pass
 
     def d2Hdq2(self, snap):
         pass

--- a/dynamiq_engine/potentials/potential_energy_surface.py
+++ b/dynamiq_engine/potentials/potential_energy_surface.py
@@ -20,6 +20,10 @@ class PotentialEnergySurface(object):
     def kinetic_energy(self, snapshot):
         return 0.5*np.dot(snapshot.velocities, snapshot.momenta)
 
+    def T(self, snapshot):
+        """T = L + V; such that L = T - V; for generic action integration"""
+        return self.kinetic_energy(snapshot)
+
     def dHdq(self, snapshot):
         dHdq = np.zeros(self.n_spatial * self.n_atoms)
         self.set_dHdq(dHdq, snapshot)

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -28,6 +28,9 @@ class testCandyRozmus4(object):
         q0 = initial_snap.coordinates[0]
         return exact_ho(time, omega, m, p0, q0, x0)
 
+    def test_prepare_bad_feature_error(self):
+        raise SkipTest
+    
     def test_cr4_step(self):
         from dynamiq_engine.features import momenta as f_momenta
         from openpathsampling.features import coordinates as f_coordinates
@@ -59,6 +62,21 @@ class testCandyRozmus4(object):
         assert_array_almost_equal(new_snap.momenta, exact_0x10['p'])
 
     def test_action(self):
+        import openpathsampling.features as paths_f
+        import dynamiq_engine.features as dynq_f
+        self.integ.prepare([paths_f.coordinates, dynq_f.momenta,
+                            dynq_f.action])
+        new_snap = dynq.Snapshot(coordinates=np.array([0.0]),
+                                 momenta=np.array([0.0]),
+                                 topology=self.topology)
+        self.integ.step(self.potential, self.snap0, new_snap)
+        for i in range(10):
+            self.integ.step(self.potential, new_snap, new_snap)
+            print new_snap.action
+        # TODO: test action is correct
+        exact = exact_ho(time=0.11, omega=1.0, m=1.0, q0=1.0, p0=0.0)
+        print new_snap.action, exact['S']
+
         raise SkipTest
 
 class testCandyRozmus4MMST(object):

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -162,10 +162,18 @@ class testCandyRozmus4MMST(object):
 
 
         tully_integ = CandyRozmus4MMST(1.0, tully)
+        import dynamiq_engine.features as dynq_f
+        import openpathsampling.features as paths_f
+        tully_integ.prepare([paths_f.coordinates, dynq_f.momenta,
+                             dynq_f.electronic_coordinates,
+                             dynq_f.electronic_momenta,
+                             dynq_f.action])
+
         tully_integ.step(tully, tully_snapshot, tully_snapshot)
 
         # NOTE: unverified -- these results are checked against the output
         # that they first gave, not against any analytical results
+        assert_not_equal(tully_snapshot.action, 0.0) # TODO: get tested val
         assert_array_almost_equal(tully_snapshot.coordinates,
                                   np.array([0.10959396]))
         assert_array_almost_equal(tully_snapshot.momenta,

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -28,15 +28,10 @@ class testCandyRozmus4(object):
         q0 = initial_snap.coordinates[0]
         return exact_ho(time, omega, m, p0, q0, x0)
 
-        #cos_wt = np.cos(omega*time)
-        #sin_wt = np.sin(omega*time)
-        #state_at_t = {
-            #'q' : np.array([q0*cos_wt + p0/m/omega*sin_wt + x0]),
-            #'p' : np.array([p0*cos_wt - q0*m*omega*sin_wt])
-        #}
-        #return state_at_t
-
     def test_cr4_step(self):
+        from dynamiq_engine.features import momenta as f_momenta
+        from openpathsampling.features import coordinates as f_coordinates
+        self.integ.prepare([f_coordinates, f_momenta])
         new_snap = dynq.Snapshot(coordinates=np.array([0.0]),
                                  momenta=np.array([0.0]),
                                  topology=self.topology)
@@ -62,6 +57,9 @@ class testCandyRozmus4(object):
         exact_0x10 = self.exact_ho(snap1, 0.10)
         assert_array_almost_equal(new_snap.coordinates, exact_0x10['q'])
         assert_array_almost_equal(new_snap.momenta, exact_0x10['p'])
+
+    def test_action(self):
+        raise SkipTest
 
 class testCandyRozmus4MMST(object):
     def test_step_uncoupled(self):

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -28,8 +28,10 @@ class testCandyRozmus4(object):
         q0 = initial_snap.coordinates[0]
         return exact_ho(time, omega, m, p0, q0, x0)
 
+    @raises(RuntimeError)
     def test_prepare_bad_feature_error(self):
-        raise SkipTest
+        import openpathsampling.features as paths_f
+        self.integ.prepare([paths_f.coordinates, paths_f.configuration])
     
     def test_cr4_step(self):
         from dynamiq_engine.features import momenta as f_momenta

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -69,15 +69,12 @@ class testCandyRozmus4(object):
         new_snap = dynq.Snapshot(coordinates=np.array([0.0]),
                                  momenta=np.array([0.0]),
                                  topology=self.topology)
-        self.integ.step(self.potential, self.snap0, new_snap)
+        exact = self.exact_ho(new_snap, 0.1)
+        self.integ.reset()
         for i in range(10):
             self.integ.step(self.potential, new_snap, new_snap)
-            print new_snap.action
         # TODO: test action is correct
-        exact = exact_ho(time=0.11, omega=1.0, m=1.0, q0=1.0, p0=0.0)
-        print new_snap.action, exact['S']
-
-        raise SkipTest
+        assert_almost_equal(new_snap.action, exact['S'])
 
 class testCandyRozmus4MMST(object):
     def test_step_uncoupled(self):

--- a/dynamiq_engine/tests/test_candy_rozmus_4.py
+++ b/dynamiq_engine/tests/test_candy_rozmus_4.py
@@ -90,6 +90,13 @@ class testCandyRozmus4MMST(object):
             topology=uncoupled_topology
         )
         uncoupled_integ = CandyRozmus4MMST(0.01, uncoupled)
+        import dynamiq_engine.features as dynq_f
+        import openpathsampling.features as paths_f
+        uncoupled_integ.prepare([paths_f.coordinates, dynq_f.momenta,
+                                 dynq_f.electronic_coordinates,
+                                 dynq_f.electronic_momenta,
+                                 dynq_f.action])
+
         for i in range(10):
             uncoupled_integ.step(uncoupled, uncoupled_snap, uncoupled_snap)
 

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -173,4 +173,3 @@ class testMMSTHamiltonian(object):
         assert_almost_equal(explicit_T(self.four_state, self.four_state_snap),
                             self.four_state.T(self.four_state_snap))
 
-        raise SkipTest

--- a/dynamiq_engine/tests/test_mmst_hamiltonian.py
+++ b/dynamiq_engine/tests/test_mmst_hamiltonian.py
@@ -159,4 +159,18 @@ class testMMSTHamiltonian(object):
             np.array([0.425, 1.0, 1.025, 0.5])
         )
 
+    def test_T(self):
+        # Definition of T is $L + V = p * dH/dp - H + V$; test this directly.
+        # Use a lambda rather than nested def because nested def screws with
+        # my in-editor test runner
+        explicit_T = lambda pes, snap : (
+            np.dot(snap.momenta, pes.dHdp(snap))
+            + np.dot(snap.electronic_momenta, pes.electronic_dHdp(snap))
+            - pes.H(snap) + pes.V(snap)
+        )
+        pes_T = self.tully.T(self.tully_snap)
+        assert_almost_equal(pes_T, explicit_T(self.tully, self.tully_snap))
+        assert_almost_equal(explicit_T(self.four_state, self.four_state_snap),
+                            self.four_state.T(self.four_state_snap))
 
+        raise SkipTest

--- a/dynamiq_engine/tests/test_potential_energy_surface.py
+++ b/dynamiq_engine/tests/test_potential_energy_surface.py
@@ -31,6 +31,23 @@ class testOneDimensionalInteractionModel(object):
         assert_almost_equal(self.pot.H(self.test_snap2), 4.25)
         assert_almost_equal(self.pot.H(self.test_snap3), 1.25)
 
+    def test_T(self):
+        # Definition of T is $L + V = p * dH/dp - H + V$; test this directly.
+        # Use a lambda rather than nested def because nested def screws with
+        # my in-editor test runner
+        explicit_T = lambda pes, snap : (
+            np.dot(snap.momenta, pes.dHdp(snap))
+            - self.pot.H(snap) + self.pot.V(snap)
+        )
+
+        assert_almost_equal(self.pot.T(self.test_snap1),
+                            explicit_T(self.pot, self.test_snap1))
+        assert_almost_equal(self.pot.T(self.test_snap2),
+                            explicit_T(self.pot, self.test_snap2))
+        assert_almost_equal(self.pot.T(self.test_snap3),
+                            explicit_T(self.pot, self.test_snap3))
+
+
     def test_dHdq(self):
         assert_array_almost_equal(self.pot.dHdq(self.test_snap1), 
                                   np.array([0.0]))

--- a/dynamiq_engine/tests/tools.py
+++ b/dynamiq_engine/tests/tools.py
@@ -19,10 +19,15 @@ def check_function(function, dictionary):
 def exact_ho(time, omega, m, p0, q0, x0=0.0):
     cos_wt = np.cos(omega*time)
     sin_wt = np.sin(omega*time)
+    cos_2wt = np.cos(2*omega*time)
+    sin_2wt = np.sin(2*omega*time)
     dq = q0-x0
     state_at_t = {
         'q' : np.array([dq*cos_wt + p0/m/omega*sin_wt + x0]),
         'p' : np.array([p0*cos_wt - dq*m*omega*sin_wt]),
-        'S' : 0.25*(p0*p0/m/omega - m*omega*dq*dq)*np.sin(2*omega*time)
+        'L' : (0.5*(p0*p0/m - m*omega*omega*dq*dq)*cos_2wt 
+               - omega*p0*dq*sin_2wt),
+        'S' : (0.25*(p0*p0/m/omega - m*omega*dq*dq)*sin_2wt
+               + 0.5*p0*dq*(cos_2wt-1.0))
     }
     return state_at_t

--- a/dynamiq_engine/tests/tools.py
+++ b/dynamiq_engine/tests/tools.py
@@ -19,8 +19,10 @@ def check_function(function, dictionary):
 def exact_ho(time, omega, m, p0, q0, x0=0.0):
     cos_wt = np.cos(omega*time)
     sin_wt = np.sin(omega*time)
+    dq = q0-x0
     state_at_t = {
-        'q' : np.array([(q0-x0)*cos_wt + p0/m/omega*sin_wt + x0]),
-        'p' : np.array([p0*cos_wt - (q0-x0)*m*omega*sin_wt])
+        'q' : np.array([dq*cos_wt + p0/m/omega*sin_wt + x0]),
+        'p' : np.array([p0*cos_wt - dq*m*omega*sin_wt]),
+        'S' : 0.25*(p0*p0/m/omega - m*omega*dq*dq)*np.sin(2*omega*time)
     }
     return state_at_t


### PR DESCRIPTION
This will add the calculation of the classical action as part of the `CandyRozmus4` integrators. So far, the action is just a property of the snapshot; it is not yet a saved object (that will come with later updates to netCDF+).

- [x] Add `action_step` to standard CR4 integrator
- [x] Test action calculation with HO exact results
- [x] Add `action_step` to MMST CR4 integrator
- [x] Test `MMSTHamiltonian.T`
- [x] Test correctness of action in MMST CR4 for uncoupled constant systems (see comment below)
- [x] Test success (not correctness) of action in MMST CR4 for Tully model