### PR TITLE
Remove frozen OPS version

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -16,7 +16,7 @@ requirements:
         - numpy
         - scipy
         - pandas
-        - openpathsampling-dev 0.0.0
+        - openpathsampling-dev
 
 
 test:


### PR DESCRIPTION
Undo the frozen OPS version set in #19. No longer needed (since a while ago) according to John Chodera. 