### PR TITLE
engine.generate should create new snapshots

### DIFF
--- a/dynamiq_engine/dynamiq_engine_core.py
+++ b/dynamiq_engine/dynamiq_engine_core.py
@@ -187,7 +187,7 @@ class DynamiqEngine(peng.DynamicsEngine):
         self.integrator.step(potential=self.potential,
                              old_snap=self._current_snapshot,
                              new_snap=self._current_snapshot)
-        return self.current_snapshot
+        return copy.deepcopy(self.current_snapshot)
 
     #def generate_n_frames(self, n):
         # TODO: we can make faster ways of doing this than in the OPS code

--- a/dynamiq_engine/tests/test_dynamiq_engine_core.py
+++ b/dynamiq_engine/tests/test_dynamiq_engine_core.py
@@ -74,7 +74,11 @@ class testDynamiqEngine(object):
                       p0=1.0, q0=1.0)
         assert_almost_equal(ho['q'], newsnap.coordinates)
         assert_almost_equal(ho['p'], newsnap.momenta)
-        assert_almost_equal(newsnap, self.engine.current_snapshot)
+        assert_true(newsnap is not snap)
+        assert_almost_equal(newsnap.coordinates, 
+                            self.engine.current_snapshot.coordinates)
+        assert_almost_equal(newsnap.momenta,
+                            self.engine.current_snapshot.momenta)
 
     def test_generate(self):
         import openpathsampling as paths
@@ -88,3 +92,24 @@ class testDynamiqEngine(object):
         self.engine.start()
         traj = self.engine.generate(snap, running=[ensemble.can_append])
         assert_equal(len(traj), 10)
+        # don't bother will all-to-all checks, but make sure the first snap
+        # is not the same as any other and that the last snap is not the
+        # same as any other
+        snap0 = traj[0]
+        snapN = traj[-1]
+        assert_true(snap0 is not snapN)
+        snap0_coord = snap0.coordinates.tolist()
+        snapN_coord = snapN.coordinates.tolist()
+        snap0_momenta = snap0.momenta.tolist()
+        snapN_momenta = snapN.momenta.tolist()
+
+        assert_not_equal(snap0_coord, snapN_coord)
+        assert_not_equal(snap0_momenta, snapN_momenta)
+        for snap in traj[1:-1]:
+            assert_true(snap0 is not snap)
+            assert_true(snapN is not snap)
+            assert_not_equal(snap0_coord, snap.coordinates.tolist())
+            assert_not_equal(snapN_coord, snap.coordinates.tolist())
+            assert_not_equal(snap0_momenta, snap.momenta.tolist())
+            assert_not_equal(snapN_momenta, snap.momenta.tolist())
+

--- a/dynamiq_engine/tests/tools.py
+++ b/dynamiq_engine/tests/tools.py
@@ -1,6 +1,6 @@
 from nose.tools import (
     assert_equal, assert_not_equal, assert_almost_equal, assert_items_equal,
-    raises
+    raises, assert_true
 )
 from nose.plugins.skip import Skip, SkipTest
 
@@ -15,6 +15,13 @@ def check_function(function, dictionary):
     """
     for test_input in dictionary.keys():
         assert_almost_equal(function(test_input), dictionary[test_input])
+
+def assert_snapshot_almost_equal(snap1, snap2):
+    assert_array_almost_equal(snap1.coordinates, snap2.coordinates)
+    assert_array_almost_equal(snap1.momenta, snap2.momenta)
+    # TODO: proper automated testing for all attributes
+
+# TODO: assert_array_differ; assert_snapshot_differ
 
 def exact_ho(time, omega, m, p0, q0, x0=0.0):
     cos_wt = np.cos(omega*time)


### PR DESCRIPTION
Previously, the trajectories returned from `engine.generate` had all frames pointing to the same snapshot, which kept getting updated during the dynamics. This fixes that.